### PR TITLE
Bump version to 0.1.2 for all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dioxus",
 ]
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dioxus",
  "ui",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "mobile"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dioxus",
  "ui",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "api",
  "dioxus",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dioxus",
  "ui",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This pull request updates the version numbers for several Rust workspace packages from `0.1.1` to `0.1.2`. No other changes are included.