### PR TITLE
Bump version to 0.1.3 and improve release workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -100,16 +100,35 @@ jobs:
           Rename-Item (Join-Path $dest ${{ matrix.bin }}) "Looplace.exe"
           Compress-Archive -Path $dest -DestinationPath (Join-Path "dist" "$out.zip") -Force
 
-      - name: Upload artifacts to release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload artifact for reuse
         uses: actions/upload-artifact@v4
         with:
           name: looplace-${{ matrix.target }}
           path: dist/*.zip
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create draft release & upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: true
+          files: dist/**/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${GITHUB_REF_NAME}" --draft=false --latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dioxus",
 ]
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dioxus",
  "ui",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "mobile"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dioxus",
  "ui",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "api",
  "dioxus",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dioxus",
  "ui",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors.workspace = true
 license.workspace = true

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This pull request updates the release workflow and bumps the version numbers across multiple Rust package manifests. The workflow changes improve artifact handling and release publishing, while the version bumps prepare all packages for a new release.

Release workflow improvements:
* Updated `.github/workflows/release-desktop.yml` to separate artifact upload from publishing, use the latest upload and download actions, create a draft release with merged artifacts, and add a step to publish the release as "latest".

Version updates:
* Bumped the version in `api/Cargo.toml` from `0.1.2` to `0.1.3`.
* Bumped the version in `desktop/Cargo.toml` from `0.1.2` to `0.1.3`.
* Bumped the version in `mobile/Cargo.toml` from `0.1.2` to `0.1.3`.
* Bumped the version in `ui/Cargo.toml` from `0.1.2` to `0.1.3`.
* Bumped the version in `web/Cargo.toml` from `0.1.2` to `0.1.3`.